### PR TITLE
Implemented safe filter on read for pyarrow with 2 tests

### DIFF
--- a/nomad/constants.py
+++ b/nomad/constants.py
@@ -1,3 +1,5 @@
+import operator
+
 # TO DO: Add other schemas
 # TO DO: Add tesselation cell default
 
@@ -29,6 +31,16 @@ ALLOWED_BUILDINGS = {
     22: ['home'], 23: ['home']
 }
 
+FILTER_OPERATORS = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">":  operator.gt,
+    ">=": operator.ge,
+    "<":  operator.lt,
+    "<=": operator.le,
+}
+
+# For trajectory generation
 DEFAULT_SPEEDS = {'park': 2/1.96,
                   'home': 0.75/1.96,
                   'work': 0.75/1.96,

--- a/nomad/io/base.py
+++ b/nomad/io/base.py
@@ -683,58 +683,38 @@ def _cast_traj_cols(df, traj_cols, parse_dates, mixed_timezone_behavior, fixed_f
     return df
 
 def _process_filters(filters, col_names):
-    """
-    Normalise *filters* into one pyarrow.dataset.Expression.
-
-    Parameters
-    ----------
-    filters : None | ds.Expression | (str, str, Any) | list[ds.Expression|tuple]
-        The user-supplied filter spec(s).  Multiple specs are AND-combined.
-    col_names : Iterable[str]
-        The set of valid column names in the dataset.
-
-    Returns
-    -------
-    ds.Expression | None
-        A single PyArrow filter expression, ready for Dataset.to_table(..., filter=expr).
-
-    Raises
-    ------
-    TypeError  : if *filters* is not recognised.
-    ValueError : if a column name is invalid or an operator unsupported.
-    """
     if filters is None:
         return None
 
-    # Always treat *filters* as an iterable of specs
-    specs = filters if isinstance(filters, (list, tuple)) else [filters]
+    # ──-- correct handling of a single tuple ───────────────────────────────
+    if isinstance(filters, ds.Expression) or (
+        isinstance(filters, tuple) and len(filters) == 3
+    ):
+        specs = [filters]          # exactly one spec
+    else:
+        specs = list(filters)      # an iterable of specs
+    # ───────────────────────────────────────────────────────────────────────
 
     exprs = []
     for spec in specs:
-        # already a PyArrow expression → use as is
         if isinstance(spec, ds.Expression):
             exprs.append(spec)
-            continue
-
-        # shorthand (“col”, “op”, value) tuple
-        if isinstance(spec, tuple) and len(spec) == 3:
+        elif isinstance(spec, tuple) and len(spec) == 3:
             col, op, val = spec
             if col not in col_names:
                 raise ValueError(f"Filter refers to unknown column {col!r}.")
             if op not in FILTER_OPERATORS:
                 raise ValueError(f"Unsupported operator {op!r}.")
             exprs.append(FILTER_OPERATORS[op](ds.field(col), val))
-            continue
+        else:
+            raise TypeError(
+                "filters must be a pyarrow Expression, a (column, op, value) tuple, "
+                "or an iterable composed of those."
+            )
 
-        raise TypeError(
-            "filters must be a PyArrow Expression, a (column, op, value) tuple, "
-            "or a list/tuple containing those."
-        )
-
-    # Combine all expressions with logical AND
     flt = exprs[0]
     for e in exprs[1:]:
-        flt = flt & e
+        flt &= e
     return flt
 
 def table_columns(filepath, format="csv", include_schema=False, sep=","):

--- a/nomad/io/base.py
+++ b/nomad/io/base.py
@@ -771,7 +771,7 @@ def table_columns(filepath, format="csv", include_schema=False, sep=","):
         header = pd.read_csv(filepath, nrows=0, sep=sep)
         return header.dtypes if include_schema else header.columns
 
-def from_df(df, traj_cols=None, parse_dates=True, mixed_timezone_behavior="naive", fixed_format=None, **kwargs):
+def from_df(df, traj_cols=None, parse_dates=True, mixed_timezone_behavior="naive", fixed_format=None, filters=None, **kwargs):
     """
     Converts a DataFrame into a standardized trajectory format by validating and casting 
     specified spatial and temporal columns.

--- a/nomad/io/base.py
+++ b/nomad/io/base.py
@@ -16,7 +16,7 @@ import numpy as np
 import geopandas as gpd
 import warnings
 import inspect
-from constants import FILTER_OPERATORS
+from nomad.constants import FILTER_OPERATORS
 import pdb
 
 import pandas as pd

--- a/nomad/io/base.py
+++ b/nomad/io/base.py
@@ -821,7 +821,7 @@ def from_df(df, traj_cols=None, parse_dates=True, mixed_timezone_behavior="naive
 
 
 def from_file(filepath, format="csv", traj_cols=None, parse_dates=True,
-              mixed_timezone_behavior="naive", fixed_format=None, sep=",", **kwargs):
+              mixed_timezone_behavior="naive", fixed_format=None, sep=",", filters=None, **kwargs):
     """
     Load and cast trajectory data from a specified file path or list of paths.
 


### PR DESCRIPTION
Passes all tests

Now users can specify a column to filter on upon reading files, which is useful to read chunks of a partitioned dataset. Implemented two unit tests for it.

The filters can run into data type issues and the user might pass a traj_cols key instead of an actual column name. Both cases are handled.