### PR TITLE
Prioritize explicit traj_cols over defaults in _fallback_time_cols_dt

### DIFF
--- a/nomad/io/base.py
+++ b/nomad/io/base.py
@@ -91,10 +91,15 @@ def _fallback_time_cols_dt(col_names, traj_cols, kwargs):
     if 'datetime' in kwargs or 'start_datetime' in kwargs: # datetime wins
         t_keys = ['datetime', 'start_datetime', 'timestamp', 'start_timestamp']
 
+    explicit_t_keys = [t_key for t_key in t_keys if t_key in traj_cols and traj_cols[t_key] in col_names]
+
     # load defaults and check for time columns
     traj_cols = _update_schema(DEFAULT_SCHEMA, traj_cols)
     _has_time_cols(col_names, traj_cols) # error if no columns
-    
+
+    if explicit_t_keys:
+        t_keys = explicit_t_keys
+
     for t_key in t_keys:
         if traj_cols[t_key] in col_names:
             use_datetime = (t_key in ['datetime', 'start_datetime']) ## necessary?


### PR DESCRIPTION
## The Problem

When a trajectory dataset contains both datetime and 	imestamp columns, NOMAD's fallback logic automatically picks one based on priority rules. But this creates a friction point: if you explicitly tell the code 'I want to use this column,' that request gets ignored if the defaults would pick something else.

This matters because real-world data often has redundant time columns—maybe your raw data has both unix seconds and formatted datetime, or you've added computed columns alongside the originals. When there's ambiguity, the code should respect your choice, not force you to delete columns just to make it cooperate.

## The Workaround (Before This Fix)

Consider hdbscan_validation_paper.py: it had to manually drop the datetime column to force the fallback to pick start_timestamp, even though the code explicitly mapped to timestamp columns. The preprocessing became:

`python
def _prep_truth(truth):
    t = truth.copy()
    # drop 'datetime' so _fallback_time_cols_dt resolves to 'start_timestamp'
    t = t.drop(columns=['datetime'], errors='ignore')
    # ... more manipulation
`

This is backwards. If you've explicitly specified 	raj_cols={'timestamp': 'start_timestamp'}, the fallback should use that, not ignore it.

## The Fix

The patch captures user-provided column mappings *before* loading defaults, then gives them priority. It's a minimal change with a clean rule: explicit mappings win.

Now you can pass data with all its natural columns intact—the code listens to what you asked for.

Fixes #233