### PR TITLE
Changed naming convention so algos can be ID'd by parameters

### DIFF
--- a/nomad/stop_detection/validation.py
+++ b/nomad/stop_detection/validation.py
@@ -1,6 +1,7 @@
 from functools import partial
 import itertools
 from pathlib import Path
+import re
 import time
 
 import matplotlib.pyplot as plt
@@ -13,7 +14,7 @@ import nomad.io.base as loader
 
 class AlgorithmRegistry:
     """Simple registry for parameterized stop-detection runs."""
-
+    
     def __init__(self):
         self._algos = []
         self._timings = []
@@ -38,6 +39,34 @@ class AlgorithmRegistry:
             if name.endswith(suffix):
                 return name[: -len(suffix)]
         return name
+
+    @staticmethod
+    def _param_codifier(value):
+        if isinstance(value, np.generic):
+            value = value.item()
+
+        if isinstance(value, float):
+            text = f"{value:.12g}"
+        elif isinstance(value, bool):
+            text = str(value).lower()
+        elif value is None:
+            text = "none"
+        else:
+            text = str(value)
+
+        text = re.sub(r"[^0-9A-Za-z_.-]+", "-", text).strip("-")
+        return text or "empty"
+
+    @classmethod
+    def _algorithm_identifier(cls, index, params):
+        if not params:
+            return f"{index:03d}"
+
+        param_parts = [
+            f"{cls._param_codifier(key)}-{cls._param_codifier(value)}"
+            for key, value in sorted(params.items())
+        ]
+        return f"{index:03d}__{'__'.join(param_parts)}"
 
     @staticmethod
     def _expand_values(value, granularity):
@@ -67,9 +96,10 @@ class AlgorithmRegistry:
 
         for index, combo in enumerate(itertools.product(*values), start=1):
             params = dict(zip(keys, combo))
+            algorithm_id = self._algorithm_identifier(index, params)
             self._algos.append(
                 {
-                    "algorithm": algorithm_name,
+                    "algorithm": algorithm_id,
                     "family": family_name,
                     "fn": fn,
                     "call": partial(fn, **params),

--- a/nomad/tests/test_stop_detection_validation.py
+++ b/nomad/tests/test_stop_detection_validation.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+from nomad.stop_detection.validation import AlgorithmRegistry
+
+
+def labels_per_user(data, dist_thresh=30, time_thresh=120, include_border_points=True):
+    return data
+
+
+def test_algorithm_registry_uses_parameter_identifier_not_family_name():
+    registry = AlgorithmRegistry()
+
+    returned_family = registry.add_algorithm(
+        labels_per_user,
+        family="seqscan",
+        dist_thresh=[30, 45],
+        time_thresh=120,
+        include_border_points=True,
+    )
+
+    algos = list(registry)
+
+    assert returned_family == "seqscan"
+    assert [algo["family"] for algo in algos] == ["seqscan", "seqscan"]
+    assert [algo["algorithm"] for algo in algos] == [
+        "001__dist_thresh-30__include_border_points-true__time_thresh-120",
+        "002__dist_thresh-45__include_border_points-true__time_thresh-120",
+    ]
+    assert all("seqscan" not in algo["algorithm"] for algo in algos)
+    assert all("labels" not in algo["algorithm"] for algo in algos)
+
+
+def test_algorithm_registry_persists_identifier_in_metrics_and_timings():
+    registry = AlgorithmRegistry()
+    registry.add_algorithm(labels_per_user, family="seqscan", dist_thresh=30)
+    algo = next(iter(registry))
+
+    annotated = registry.annotate_metrics({"precision": 1.0}, algo)
+    output = registry.time_call(algo, pd.DataFrame({"x": [1, 2, 3]}))
+    timings = registry.timing_frame()
+
+    assert output["x"].tolist() == [1, 2, 3]
+    assert annotated["algorithm"] == "001__dist_thresh-30"
+    assert annotated["family"] == "seqscan"
+    assert timings.loc[0, "algorithm"] == "001__dist_thresh-30"
+    assert timings.loc[0, "family"] == "seqscan"


### PR DESCRIPTION
Basically two methods:
_param_codifier(value), which converts a parameter value into a standardized string

- Convert NumPy scalar types to native Python types.
- Format values consistently (e.g., floats with up to 12 significant digits, booleans and None in lowercase)
- Convert all other values to strings
- Replace non-alphanumeric characters (except ., _, and -) with hyphens
- Remove leading/trailing hyphens
- Return "empty" if the resulting string is blank

_algorithm_identifier(index, params)

- Return the zero-padded algorithm index if no parameters are provided
- Sort the parameter dictionary by key to ensure a consistent ordering
- Encode each parameter as <key>-<value> using _param_codifier()
- Join the encoded parameters with "__"
- Prefix the result with the zero-padded algorithm index