### PR TITLE
Support external AlgorithmRegistry parameters

### DIFF
--- a/nomad/stop_detection/validation.py
+++ b/nomad/stop_detection/validation.py
@@ -112,7 +112,7 @@ class AlgorithmRegistry:
             call_params = {
                 key: value
                 for key, value in params.items()
-                if key in param_specs
+                if key not in external_params
             }
             algorithm_id = self._algorithm_identifier(index, params)
             self._algos.append(

--- a/nomad/stop_detection/validation.py
+++ b/nomad/stop_detection/validation.py
@@ -82,13 +82,26 @@ class AlgorithmRegistry:
 
         return [value]
 
-    def add_algorithm(self, fn, family=None, granularity=30, **param_specs):
+    def add_algorithm(
+        self,
+        fn,
+        family=None,
+        granularity=30,
+        external_params=None,
+        **param_specs,
+    ):
+        """Register every combination of the supplied parameter specifications.
+
+        ``external_params`` defines parameters that identify and annotate a run
+        but are consumed before invocation rather than passed to ``fn``.
+        """
         algorithm_name = self._normalize_algorithm_name(fn.__name__)
         family_name = family or self._next_auto_family(algorithm_name)
+        external_params = external_params or {}
 
         expanded = {
             key: self._expand_values(value, granularity)
-            for key, value in param_specs.items()
+            for key, value in {**param_specs, **external_params}.items()
         }
 
         keys = list(expanded.keys())
@@ -96,13 +109,18 @@ class AlgorithmRegistry:
 
         for index, combo in enumerate(itertools.product(*values), start=1):
             params = dict(zip(keys, combo))
+            call_params = {
+                key: value
+                for key, value in params.items()
+                if key in param_specs
+            }
             algorithm_id = self._algorithm_identifier(index, params)
             self._algos.append(
                 {
                     "algorithm": algorithm_id,
                     "family": family_name,
                     "fn": fn,
-                    "call": partial(fn, **params),
+                    "call": partial(fn, **call_params),
                     "params": params,
                 }
             )

--- a/nomad/tests/test_stop_detection_validation.py
+++ b/nomad/tests/test_stop_detection_validation.py
@@ -44,3 +44,27 @@ def test_algorithm_registry_persists_identifier_in_metrics_and_timings():
     assert annotated["family"] == "seqscan"
     assert timings.loc[0, "algorithm"] == "001__dist_thresh-30"
     assert timings.loc[0, "family"] == "seqscan"
+
+
+def test_algorithm_registry_tracks_external_parameters_without_forwarding_them():
+    registry = AlgorithmRegistry()
+    registry.add_algorithm(
+        labels_per_user,
+        family="gridbased",
+        external_params={"h3_resolution": [8, 9]},
+        dist_thresh=[30, 45],
+    )
+
+    algos = list(registry)
+    output = registry.time_call(algos[0], pd.DataFrame({"x": [1, 2, 3]}))
+    annotated = registry.annotate_metrics({"recall": 1.0}, algos[0])
+
+    assert [algo["algorithm"] for algo in algos] == [
+        "001__dist_thresh-30__h3_resolution-8",
+        "002__dist_thresh-30__h3_resolution-9",
+        "003__dist_thresh-45__h3_resolution-8",
+        "004__dist_thresh-45__h3_resolution-9",
+    ]
+    assert output["x"].tolist() == [1, 2, 3]
+    assert algos[0]["params"]["h3_resolution"] == 8
+    assert annotated["h3_resolution"] == 8


### PR DESCRIPTION
## Why
Some experiment configurations include parameters that affect preprocessing and run identity without belonging to the stop-detection callable. `AlgorithmRegistry` should expand and annotate those values without forwarding them to the registered function.

## Change
- Add an `external_params` parameter-spec mapping to `add_algorithm`.
- Include external values in Cartesian expansion, identifiers, timing rows, and metric annotations.
- Exclude external values from the partially applied algorithm call.
- Cover mixed callable/external parameter expansion and invocation in the registry tests.

Existing `add_algorithm` calls are unchanged. Pylance reports all 14 Python call sites compatible, and the paired example notebooks pass strict Jupytext round-trip checks.

## Validation
- `python -m pytest nomad/tests/test_stop_detection_validation.py -q` (3 passed)
- `python -m pytest nomad/tests -q` (422 passed, 9 skipped, 3 xfailed)

This pull request includes code written with the assistance of AI. The code has not yet been reviewed by a human (remove this disclosure after human review).